### PR TITLE
Add password reset/change functionality

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -77,8 +77,11 @@ config :guardian_db, GuardianDb,
   repo: PhoenixGuardian.Repo,
   sweep_interval: 60 # 60 minutes
 
+config :phoenix_guardian, PhoenixGuardian.Mailer,
+  adapter: Bamboo.LocalAdapter,
+  from_mail: "your_email@your_domain",
+  reply_to_mail: "your_email@your_domain"
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"
-

--- a/lib/phoenix_guardian/mailer.ex
+++ b/lib/phoenix_guardian/mailer.ex
@@ -1,0 +1,3 @@
+defmodule PhoenixGuardian.Mailer do
+  use Bamboo.Mailer, otp_app: :phoenix_guardian
+end

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -1,0 +1,140 @@
+defmodule PhoenixGuardian.PasswordController do
+  use PhoenixGuardian.Web, :controller
+
+  alias PhoenixGuardian.{Authorization, Email, Mailer, User}
+
+  @max_token_age 172_800 # reset token good for 48 hours
+
+  # new sets up the request for a new password (reset) form
+  # asks user for email
+  def new(conn, params), do: new(conn, params, nil, nil)
+  def new(conn, _params, current_user, _claims) do
+    render conn, "new.html", current_user: current_user
+  end
+
+  # create checks that user w/ email exists and...
+  # authorization is identity provider
+  # if not user, user not found message
+  # if not auth w/ identity provider, message that they should login via Facebook
+  # if there is user w/ identity auth, create token from auth id & send link to edit action via email
+  def create(conn, params), do: create(conn, params, nil, nil)
+  def create(conn, %{"email" => email}, current_user, _claims) do
+    user = Repo.get_by(User, email: email)
+
+    if user do
+      manage_password_reset_email user, conn
+    else
+      conn
+      |> put_flash(:error, "Sorry! We couldn't find an account for #{email}.")
+      |> render("new.html", current_user: current_user)
+    end
+  end
+
+  def edit(conn, params), do: edit(conn, params, nil, nil)
+  def edit(conn, %{"token" => token}, current_user, _claims) do
+    # authorization.id comes in as a token within expiry that can verify
+    case Phoenix.Token.verify(PhoenixGuardian.Endpoint, "auth", token, max_age: @max_token_age) do
+      {:ok, id} ->
+        # get matching authorization so we can update its token (aka password for identity provider)
+        # even though we have id, limit to identity provider so attackers can't reset tokens for other provider types
+        authorization = Repo.get_by!(Authorization, id: id, provider: "identity")
+        render(conn, "edit.html", token: token, current_user: current_user)
+      {:error, :expired} -> report_expired(conn)
+      {:error, :invalid} -> return_invalid(conn)
+    end
+  end
+
+  # logged in user editing their password
+  def edit(conn, _params, %User{} = current_user, _claims) do
+    current_user = current_user |> Repo.preload(:authorizations)
+    auth = identity_auth_for(current_user)
+
+    if auth do
+      render(conn,
+             "edit.html",
+             token: Phoenix.Token.sign(PhoenixGuardian.Endpoint, "auth", auth.id),
+             current_user: current_user)
+    else
+      redirect_to_facebook_login conn
+    end
+  end
+
+  # assume that logged out user w/ no token is attack, return 404
+  def edit(conn, _params, _current_user = nil, _claims) do
+    return_invalid(conn)
+  end
+
+  def update(conn, params), do: edit(conn, params, nil, nil)
+  # double check token
+  # return error if not valid match for auth
+  # update auth's token value w/ submitted password
+  # redirect to login form
+  def update(conn, %{"token" => token, "password" => password}, current_user, _claims) do
+    case Phoenix.Token.verify(PhoenixGuardian.Endpoint, "auth", token, max_age: @max_token_age) do
+      {:ok, id} -> update_token_with_password(id, password, conn, token, current_user)
+      {:error, :expired} -> report_expired(conn)
+      {:error, :invalid} -> return_invalid(conn)
+    end
+  end
+
+  # get matching authorization so we can update its token (aka password for identity provider)
+  # even though we have id, limit to identity provider so attackers can't reset tokens for other provider types
+  defp update_token_with_password(id, password, conn, token, current_user) do
+    authorization = Repo.get_by!(Authorization, id: id, provider: "identity")
+    changeset = Authorization.hash_token_changeset(authorization, %{token: password})
+
+    case Repo.update(changeset) do
+      {:ok, _} ->
+        conn
+        |> put_flash(:info, "Password updated successfully.")
+        |> redirect(to: auth_path(conn, :login, "identity"))
+      {:error, _changeset} ->
+        # TODO error feedback for user
+        render(conn, "edit.html", token: token, current_user: current_user)
+    end
+  end
+
+  defp identity_auth_for(user) do
+    user.authorizations
+    |> Enum.filter(fn auth -> auth.provider == "identity" end)
+    |> List.first
+  end
+
+  defp redirect_to_facebook_login(conn) do
+    conn
+    |> put_flash(:error, "Looks like you used Facebook to login. Please click Facebook button below to login.")
+    |> redirect(to: auth_path(conn, :login, "identity"))
+  end
+
+  defp report_expired(conn) do
+    conn
+    |> put_flash(:error, "Sorry! Your reset request has expired. Please try again.")
+    |> redirect(to: auth_path(conn, :login, "identity"))
+  end
+
+  defp return_invalid(conn) do
+    # assumes that invalid is attack, just return not found error
+    conn
+    |> put_layout(false)
+    |> put_status(404)
+    |> render(PhoenixGuardian.ErrorView, "404.html")
+  end
+
+  defp manage_password_reset_email(user, conn) do
+    user = user |> Repo.preload(:authorizations)
+    auth = identity_auth_for(user)
+
+    if auth do
+      # create token and send reset email
+      user
+      |> Email.password_reset_email(Phoenix.Token.sign(PhoenixGuardian.Endpoint, "auth", auth.id))
+      |> Mailer.deliver_later
+
+      conn
+      |> put_flash(:info, "A link to reset your password has been sent to #{user.email}")
+      |> redirect(to: auth_path(conn, :login, "identity"))
+    else
+      redirect_to_facebook_login conn
+    end
+  end
+end

--- a/web/email.ex
+++ b/web/email.ex
@@ -1,0 +1,17 @@
+defmodule PhoenixGuardian.Email do
+  use Bamboo.Phoenix, view: PhoenixGuardian.EmailView
+
+  def password_reset_email(user, token) do
+    base_email
+    |> to(user)
+    |> subject("Your Password Reset Link")
+    |> render(:password_reset, user: user, token: token)
+  end
+
+  defp base_email do
+    new_email
+    |> from(Application.get_env(:phoenix_guardian, PhoenixGuardian.Mailer)[:from_mail])
+    |> put_header("Reply-To", Application.get_env(:phoenix_guardian, PhoenixGuardian.Mailer)[:reply_to_mail])
+    |> put_html_layout({PhoenixGuardian.LayoutView, "email.html"})
+  end
+end

--- a/web/models/authorization.ex
+++ b/web/models/authorization.ex
@@ -31,4 +31,20 @@ defmodule PhoenixGuardian.Authorization do
     |> foreign_key_constraint(:user_id)
     |> unique_constraint(:provider_uid)
   end
+
+  def hash_token_changeset(model, params \\ %{}) do
+    model
+    |> changeset(params)
+    |> hash_token_input
+  end
+
+  defp hash_token_input(changeset) do
+    token = get_change(changeset, :token)
+
+    if token do
+      put_change(changeset, :token, Comeonin.Bcrypt.hashpwsalt(token))
+    else
+      changeset
+    end
+  end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -41,3 +41,10 @@ defmodule PhoenixGuardian.User do
     |> Repo.update!
   end
 end
+
+defimpl Bamboo.Formatter, for: PhoenixGuardian.User do
+  # Used by `to`, `bcc`, `cc` and `from`
+  def format_email_address(user, _opts) do
+    {user.name || user.name, user.email}
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -1,6 +1,10 @@
 defmodule PhoenixGuardian.Router do
   use PhoenixGuardian.Web, :router
 
+  if Mix.env == :dev do
+    forward "/sent_emails", Bamboo.EmailPreviewPlug
+  end
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -59,6 +63,7 @@ defmodule PhoenixGuardian.Router do
     resources "/users", UserController
     resources "/authorizations", AuthorizationController
     resources "/tokens", TokenController
+    resources "/password", PasswordController, only: [:new, :create, :edit, :update], singleton: true
 
     get "/private", PrivatePageController, :index
   end

--- a/web/templates/auth/login.html.eex
+++ b/web/templates/auth/login.html.eex
@@ -58,6 +58,7 @@
           </div>
         <% end %>
         <p><%= link "Signup with your email", to: user_path(@conn, :new) %></p>
+        <p>Trouble logging in? <%= link "Reset your password here", to: password_path(@conn, :new) %></p>
       <% end %>
     </div>
   </div>

--- a/web/templates/email/password_reset.html.eex
+++ b/web/templates/email/password_reset.html.eex
@@ -1,0 +1,1 @@
+<p><%= link "Reset your password", to: password_url(PhoenixGuardian.Endpoint, :edit, token: @token) %></p>

--- a/web/templates/email/password_reset.text.eex
+++ b/web/templates/email/password_reset.text.eex
@@ -1,0 +1,1 @@
+Reset your password: <%= password_url(PhoenixGuardian.Endpoint, :edit, token: @token) %>

--- a/web/templates/layout/email.html.eex
+++ b/web/templates/layout/email.html.eex
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="<%= static_url(PhoenixGuardian.Endpoint, "/css/email.css") %>">
+  </head>
+  <body>
+    <%= render @view_module, @view_template, assigns %>
+  </body>
+</html>

--- a/web/templates/password/edit.html.eex
+++ b/web/templates/password/edit.html.eex
@@ -1,0 +1,15 @@
+<%= form_tag password_path(@conn, :update), [method: "PUT"] do %>
+  <input type="hidden" name="token" value="<%= @token %>">
+
+  <p>
+    Enter a new password below and we'll update your Cubspot account.
+  </p>
+
+  <div class="input-group">
+    <span class="icon icon-outline icon-lock label-group"></span>
+    <input type="password" name="password" class="with-icon" placeholder="Password" required/>
+    <!-- <label class="account-label label-group" for="password-input">Password</label> -->
+  </div>
+
+  <button>Update Password</button>
+<% end %>

--- a/web/templates/password/new.html.eex
+++ b/web/templates/password/new.html.eex
@@ -1,0 +1,12 @@
+<%= form_tag password_path(@conn, :create) do %>
+  <p>
+    Enter the email address associated with your account, and we'll email you a link to reset your password.
+  </p>
+  <div class="input-group">
+    <span class="icon icon-outline icon-mail label-group"></span>
+    <input type="email" name="email" class="with-icon" placeholder="Email address" required/>
+    <!-- <label class="account-label label-group" for="email-input">Email address</label> -->
+  </div>
+
+  <button>Send Request Link</button>
+<% end %>

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -1,0 +1,3 @@
+defmodule PhoenixGuardian.EmailView do
+  use PhoenixGuardian.Web, :view
+end

--- a/web/views/password_view.ex
+++ b/web/views/password_view.ex
@@ -1,0 +1,3 @@
+defmodule PhoenixGuardian.PasswordView do
+  use PhoenixGuardian.Web, :view
+end


### PR DESCRIPTION
This implements the ability for users to request a password reset and receive an email with a token to change their password.

It also allows for logged in users to change their password by directly navigating to `/password/edit`.

Currently WIP. Waiting for PR #32 to update dependencies before adding necessary addition of Bamboo dependency to `mix.exs`.

May need additional styling, too.

Demonstrates functionality needed to satisfy #36.

Appreciate feedback on if there are any security gotchas with issuing a `Phoenix.Token` for `Authorization` `id`.
